### PR TITLE
IL-95-Textarea: remove useState, add finalId

### DIFF
--- a/src/components/textarea/Textarea.stories.ts
+++ b/src/components/textarea/Textarea.stories.ts
@@ -7,14 +7,10 @@ const meta = {
     disabled: {
       control: { type: 'boolean' },
     },
-    error: {
-      control: { type: 'boolean' },
-    },
     onValueChange: {
       action: 'on Value Change',
     },
   },
-  args: { errorMessage: 'Error text' },
   component: Textarea,
   tags: ['autodocs'],
   title: 'Components/Textarea',
@@ -26,30 +22,24 @@ type Story = StoryObj<typeof meta>
 export const TextareaDefault: Story = {
   args: {
     disabled: false,
-    error: false,
     label: 'Textarea',
     placeholder: 'Textarea Placeholder',
-    initialValue: 'Textarea',
   },
 }
 
 export const TextareaError: Story = {
   args: {
     disabled: false,
-    error: true,
     errorMessage: 'Error text',
     label: 'Textarea',
     placeholder: 'Textarea Placeholder',
-    initialValue: 'Textarea',
   },
 }
 
 export const TextareaDisabled: Story = {
   args: {
     disabled: true,
-    error: false,
     label: 'Textarea',
     placeholder: 'Textarea Placeholder',
-    initialValue: 'Textarea',
   },
 }

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -2,59 +2,44 @@ import { ChangeEvent, ComponentPropsWithoutRef, forwardRef, useState } from 'rea
 import s from './textarea.module.scss'
 import { clsx } from 'clsx'
 import { Typography, TypographyVariant } from '../typography'
+import { useFinalId } from '../../hooks/useFinalId.ts'
 
-s
 export type TextareaProps = {
   label?: string
   onValueChange?: (value: string) => void
-  initialValue?: string
-  error?: boolean
   errorMessage?: string
 } & ComponentPropsWithoutRef<'textarea'>
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
-    {
-      label,
-      className,
-      error,
-      errorMessage,
-      onChange,
-      onValueChange,
-      placeholder,
-      disabled,
-      initialValue = '',
-      ...restProps
-    },
+    { label, className, id, errorMessage, onValueChange, placeholder, disabled, ...restProps },
     forwardedRef
   ) => {
-    const [currentValue, setCurrentValue] = useState(initialValue)
+    const finalId = useFinalId(id)
 
     function handleChange(ev: ChangeEvent<HTMLTextAreaElement>) {
-      setCurrentValue(ev.target.value)
-      onChange?.(ev)
       onValueChange?.(ev.currentTarget.value)
     }
 
     return (
       <div className={clsx(s.textareaRootContainer, className)}>
         {label && (
-          <label className={clsx(s.label, disabled && s.disabled)}>
+          <label className={clsx(s.label, disabled && s.disabled)} htmlFor={finalId}>
             <Typography variant={TypographyVariant.regular_text_14}>{label}</Typography>
           </label>
         )}
         <div className={s.fieldContainer}>
           <textarea
-            className={clsx(s.textarea, error && s.error)}
+            className={clsx(s.textarea, errorMessage && s.error)}
+            id={finalId}
             onChange={handleChange}
             placeholder={placeholder}
             disabled={disabled}
-            value={currentValue}
             ref={forwardedRef}
             {...restProps}
           />
         </div>
-        {error && (
+        {errorMessage && (
           <div className={s.error}>
             <Typography variant={TypographyVariant.regular_text_14}>{errorMessage}</Typography>
           </div>


### PR DESCRIPTION
useState is removed since the Textarea will be transformed in FromTextarea (controlled Textarea working through props control of react-hook-form)

finalId returned from useFinalId is used to connect label with textarea