### PR TITLE
IL-95.1 changes on Textarea

### DIFF
--- a/src/components/textarea/Textarea.stories.ts
+++ b/src/components/textarea/Textarea.stories.ts
@@ -7,8 +7,8 @@ const meta = {
     disabled: {
       control: { type: 'boolean' },
     },
-    onValueChange: {
-      action: 'on Value Change',
+    onChange: {
+      action: 'on Change',
     },
   },
   component: Textarea,

--- a/src/components/textarea/Textarea.stories.ts
+++ b/src/components/textarea/Textarea.stories.ts
@@ -7,14 +7,10 @@ const meta = {
     disabled: {
       control: { type: 'boolean' },
     },
-    error: {
-      control: { type: 'boolean' },
-    },
     onValueChange: {
       action: 'on Value Change',
     },
   },
-  args: { errorMessage: 'Error text' },
   component: Textarea,
   tags: ['autodocs'],
   title: 'Components/Textarea',
@@ -26,30 +22,24 @@ type Story = StoryObj<typeof meta>
 export const TextareaDefault: Story = {
   args: {
     disabled: false,
-    error: false,
     label: 'Textarea',
     placeholder: 'Textarea Placeholder',
-    initialValue: 'Textarea',
   },
 }
 
 export const TextareaError: Story = {
   args: {
     disabled: false,
-    error: true,
     errorMessage: 'Error text',
     label: 'Textarea',
     placeholder: 'Textarea Placeholder',
-    initialValue: 'Textarea',
   },
 }
 
 export const TextareaDisabled: Story = {
   args: {
     disabled: true,
-    error: false,
     label: 'Textarea',
     placeholder: 'Textarea Placeholder',
-    initialValue: 'Textarea',
   },
 }

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -1,25 +1,37 @@
-import { ChangeEvent, ComponentPropsWithoutRef, forwardRef, useState } from 'react'
+import { ComponentPropsWithoutRef, forwardRef } from 'react'
 import s from './textarea.module.scss'
 import { clsx } from 'clsx'
 import { Typography, TypographyVariant } from '../typography'
 import { useFinalId } from '../../hooks/useFinalId.ts'
 
+/**
+ * @param {Object} props - The properties passed to the Textarea component.
+ * @param {string} [props.label] - Optional label displayed above the textarea.
+ * @param {string} [props.errorMessage] - Optional error message displayed below the textarea.
+ * @param {string} [props.className] - Optional additional CSS class to style the textarea container.
+ * @param {string} [props.id] - Optional custom id for the textarea element. If not provided, an auto-generated id is used.
+ * @param {boolean} [props.disabled] - If `true`, disables the textarea input.
+ */
 export type TextareaProps = {
   label?: string
-  onValueChange?: (value: string) => void
   errorMessage?: string
 } & ComponentPropsWithoutRef<'textarea'>
 
+/**
+ * A reusable Textarea component that supports labels, error messages,
+ * and integrates with React forwardRef API.
+ *
+ * @example
+ * // Usage in a form
+ * <Textarea
+ *   label="Description"
+ *   errorMessage="Please provide a valid description."
+ *   placeholder="Enter description"
+ * />
+ */
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  (
-    { label, className, id, errorMessage, onValueChange, placeholder, disabled, ...restProps },
-    forwardedRef
-  ) => {
+  ({ label, errorMessage, className, id, disabled, ...restProps }, forwardedRef) => {
     const finalId = useFinalId(id)
-
-    function handleChange(ev: ChangeEvent<HTMLTextAreaElement>) {
-      onValueChange?.(ev.currentTarget.value)
-    }
 
     return (
       <div className={clsx(s.textareaRootContainer, className)}>
@@ -32,8 +44,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           <textarea
             className={clsx(s.textarea, errorMessage && s.error)}
             id={finalId}
-            onChange={handleChange}
-            placeholder={placeholder}
             disabled={disabled}
             ref={forwardedRef}
             {...restProps}

--- a/src/components/textarea/Textarea.tsx
+++ b/src/components/textarea/Textarea.tsx
@@ -2,59 +2,44 @@ import { ChangeEvent, ComponentPropsWithoutRef, forwardRef, useState } from 'rea
 import s from './textarea.module.scss'
 import { clsx } from 'clsx'
 import { Typography, TypographyVariant } from '../typography'
+import { useFinalId } from '../../hooks/useFinalId.ts'
 
-s
 export type TextareaProps = {
   label?: string
   onValueChange?: (value: string) => void
-  initialValue?: string
-  error?: boolean
   errorMessage?: string
 } & ComponentPropsWithoutRef<'textarea'>
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
-    {
-      label,
-      className,
-      error,
-      errorMessage,
-      onChange,
-      onValueChange,
-      placeholder,
-      disabled,
-      initialValue = '',
-      ...restProps
-    },
+    { label, className, id, errorMessage, onValueChange, placeholder, disabled, ...restProps },
     forwardedRef
   ) => {
-    const [currentValue, setCurrentValue] = useState(initialValue)
+    const finalId = useFinalId(id)
 
     function handleChange(ev: ChangeEvent<HTMLTextAreaElement>) {
-      setCurrentValue(ev.target.value)
-      onChange?.(ev)
       onValueChange?.(ev.currentTarget.value)
     }
 
     return (
       <div className={clsx(s.textareaRootContainer, className)}>
         {label && (
-          <label className={clsx(s.label, disabled && s.disabled)}>
+          <label className={clsx(s.label, disabled && s.disabled)} htmlFor={finalId}>
             <Typography variant={TypographyVariant.regular_text_14}>{label}</Typography>
           </label>
         )}
         <div className={s.fieldContainer}>
           <textarea
-            className={clsx(s.textarea, error && s.error)}
+            className={clsx(s.textarea, errorMessage && s.error)}
+            id={finalId}
             onChange={handleChange}
             placeholder={placeholder}
             disabled={disabled}
-            value={currentValue}
             ref={forwardedRef}
             {...restProps}
           />
         </div>
-        {error && (
+        {errorMessage && (
           <div className={s.error}>
             <Typography variant={TypographyVariant.regular_text_14}>{errorMessage}</Typography>
           </div>


### PR DESCRIPTION
1. To further modify the Textarea component for control by react-hook-form, the following adjustments were made:

a. Remove useState: since react-hook-form will manage the state;
b. Remove the onValueChange prop: react-hook-form will handle value changes.

2. To connect label and textarea, finalId returned by useFinalId was added.